### PR TITLE
ログイン時toastメッセージの重複　修正

### DIFF
--- a/app/authguard/AuthGuard.tsx
+++ b/app/authguard/AuthGuard.tsx
@@ -24,8 +24,9 @@ export const AuthGuard = ({ children }: Props) => {
         isClosable: true,
       });
       router.push('/signin')
-    }else if (user){
+    }else if (user && !toast.isActive('login-toast')){
       toast({
+        id: 'login-toast',
         title: 'ログインしました',
         status: 'success',
         duration: 5000,


### PR DESCRIPTION
close #51 

## やったこと・変更内容（ビューの変更がある場合はスクショによる比較などがあるとわかりやすい ）
ログイン時tastメッセージの重複 修正
- [ ]

## レビュー観点（レビューをする際に見てほしい点など）
ログイン時、「ログインしました」のメッセージが１回しか表示されないこと（修正前は「ログインしました」のメッセージが３つも表示されていた）
-
