### PR TITLE
ページ遷移時useEffectが際レンダリングされるのを修正/page.tsxプッシュ漏れ

### DIFF
--- a/app/authguard/AuthGuard.tsx
+++ b/app/authguard/AuthGuard.tsx
@@ -25,15 +25,21 @@ export const AuthGuard = ({ children }: Props) => {
         duration: 5000,
         isClosable: true,
       });
+      //ログアウト時にsessionStrageの中身をクリアにする
+      sessionStorage.removeItem('login-toast');
       router.push('/signin')
-    }else if (user && !toast.isActive('login-toast')){
-      toast({
-        id: 'login-toast',
-        title: 'ログインしました',
-        status: 'success',
-        duration: 5000,
-        isClosable: true,
-      })
+    }
+    if (user && !sessionStorage.getItem('login-toast')){
+      if(!toast.isActive('login-toast')) {
+        toast({
+          id: 'login-toast',
+          title: 'ログインしました',
+          status: 'success',
+          duration: 5000,
+          isClosable: true,
+        });
+        sessionStorage.setItem('login-toast', 'true')
+      }
     }
   }, [user, router, toast])
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -39,6 +39,11 @@ export default function Home({ Component, pageProps }: AppProps) {
   const endIndex = startIndex + itemPerPage;
   const displayedPosts = posts.slice(startIndex, endIndex);
 
+  const handleCardClick = (postId: string) => {
+    router.push(`/${postId}`)
+  }
+
+
   return (
     <AuthProvider>
       <AuthGuard>
@@ -74,7 +79,17 @@ export default function Home({ Component, pageProps }: AppProps) {
 
             <SimpleGrid columns={[1, 1, 2, 3]} spacing={3}>
               {displayedPosts.map((post) => (
-                <Card key={post.id} border="1" borderRadius="md" maxW="467px" maxH="498px" mx="3" my="5">
+                <Card
+                  key={post.id}
+                  border="1"
+                  borderRadius="md"
+                  maxW="467px"
+                  maxH="498px"
+                  mx="3"
+                  my="5"
+                  onClick={() => handleCardClick(post.id)}
+                  cursor="pointer"
+                  >
                   <CardBody p="0" borderTopRadius="md" maxH="inherit">
                     <Image
                       borderTopRadius="md"


### PR DESCRIPTION
close #61 

## やったこと・変更内容（ビューの変更がある場合はスクショによる比較などがあるとわかりやすい ）
ページ遷移時useEffectが際レンダリングされるのを修正/page.tsxプッシュ漏れ

- [ ]

## レビュー観点（レビューをする際に見てほしい点など）
・ページ遷移時にAuthGuardのuseEfectが再レンダリングされページ遷移時に「ログインしました」のトーストメッセージが出ていたのでページを遷移してもトーストメッセージが表示されないこと
・前回のプッシュ漏れ。トップページの記事カードをクリックすると詳細ページへ遷移できるか確認願います。
-
