### PR TITLE
fix/blogtop_layout_#64

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -24,6 +24,9 @@ export default function Home() {
   // 検索用の状態
   const [searchTerm, setSearchTerm] = useState<string>("");
 
+  // 画像エラーの場合
+  const [imageError, setImageError] = useState<string>("");
+
   useEffect(() => {
     const page = parseInt(searchParams.get('p') || '1', 10);
     setCurrentPage(page);
@@ -109,23 +112,41 @@ export default function Home() {
                   my="5"
                   onClick={() => handleCardClick(post.id)}
                   cursor="pointer"
-                  >
+                >
                   <Link href={`/${post.id}`}>
-                    <CardBody p="0" borderTopRadius="md" maxH="inherit">
+                    <CardBody p="0" borderTopRadius="md" height="498px" maxH="inherit">
                       <Image
                         borderTopRadius="md"
                         objectFit='cover'
                         src={post.image_path}
                         alt={post.title}
-                        maxH="inherit"
+                        width="100%"
+                        maxHeight="62%"
+                        onError={() => setImageError(post.id)}
+                        display={imageError === post.id ? "none" : "block"}
+
+
                       />
+                      {imageError === post.id && (
+                        <Box
+                          display="flex"
+                          alignItems="center"
+                          justifyContent="center"
+                          height="62%"
+                          width="100%"
+                          bg="gray.200"
+                          borderTopRadius="md"
+                        >
+                          <Text color="gray.500" fontSize="lg">No Image</Text>
+                        </Box>
+                      )}
                       <Box>
                         <Stack px='5' spacing='2' py='4'>
                           <Text mt={1} color="gray.500" textAlign="right">{post.categoryName}</Text>
                           <Heading size='md'>{post.title}</Heading>
                           <Box display='flex' alignItems='center' >
-                            <Text mt={1} color="gray.500">{post.userName}</Text>
-                            <Text mt={1} color="gray.500" marginLeft='5'>{new Date(post.created_at).toLocaleDateString()}</Text>
+                            <Text mt={1} color="blue.400">{post.userName}</Text>
+                            <Text mt={1} color="blue.400" marginLeft='5'>{new Date(post.created_at).toLocaleDateString()}</Text>
                           </Box>
                           <Box
                             fontSize={["sm", "md", "lg", "xl"]}

--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -9,6 +9,7 @@ import { usePosts } from "../hooks/UsePosts";
 import { convertDraftContentToHTML } from "../utils/convertDraftContentToHTML";
 import { auth } from "@/firebase";
 import { useAuthState } from "react-firebase-hooks/auth";
+import Link from "next/link";
 
 
 export default function Profile() {
@@ -25,6 +26,11 @@ export default function Profile() {
   const DisplayedPersonalPosts = posts.filter(post => post.user_id === user?.uid).slice(startIndex, endIndex);
 
 
+  // 画像エラーの場合
+  const [imageError, setImageError] = useState<string>("");
+
+
+
   if (loading) {
     return <Center><Box mt='20' color="gray.500">Loading...</Box></Center>;
   }
@@ -39,7 +45,7 @@ export default function Profile() {
           <Stack mt="6" spacing="3"></Stack>
           <Box as="div" mx="0 auto">
             <Center>
-              <Heading size="2xl" m="5" color="gray.500">Your Post</Heading>
+              <Heading size="2xl" m="5" color="black.500">Your Post</Heading>
             </Center>
           </Box>
 
@@ -47,39 +53,63 @@ export default function Profile() {
             <SimpleGrid columns={[1, 1, 2, 3]} spacing={3}>
               {DisplayedPersonalPosts.map((post) => (
                 <Card key={post.id} border="1" borderRadius="md" maxW="467px" maxH="498px" mx="3" my="5">
-                  <CardBody p="0" borderTopRadius="md" maxH="inherit">
-                    <Image
-                      borderTopRadius="md"
-                      objectFit='cover'
-                      src={post.image_path || "https://placehold.jp/467x304.png"} // デフォルト画像を使用
-                      alt={post.title}
-                      maxH="inherit"
-                    />
-                    <Box>
-                      <Stack px='5' spacing='2' py='4'>
-                        <Text mt={1} color="gray.500" textAlign="right">{post.category_id || "Unknown Category"}</Text>
-                        <Heading size='md'>{post.title}</Heading>
-                        <Box display='flex' alignItems='center' >
-                          <Text mt={1} color="gray.500">{post.user_id || "Unknown Author"}</Text>
-                          <Text mt={1} color="gray.500" marginLeft='5'>
-                            {new Date(post.created_at).toLocaleDateString()}
-                          </Text>
-                        </Box>
+                  <Link href={`/${post.id}`}>
+                    <CardBody p="0" borderTopRadius="md" height="498px" maxH="inherit">
+                      <Image
+                        borderTopRadius="md"
+                        objectFit='cover'
+                        src={post.image_path}
+                        alt={post.title}
+                        width="100%"
+                        maxHeight="62%"
+                        onError={() => setImageError(post.id)}
+                        display={imageError === post.id ? "none" : "block"}
+
+
+                      />
+                      {imageError === post.id && (
                         <Box
-                          fontSize={["sm", "md", "lg", "xl"]}
-                          mb={2}
-                          // 文字を２行で省略
-                          sx={{
-                            display: "-webkit-box",
-                            WebkitBoxOrient: "vertical",
-                            WebkitLineClamp: 2,
-                            overflow: "hidden",
-                          }}
-                          dangerouslySetInnerHTML={{ __html: convertDraftContentToHTML(post.content) }}
-                        />
-                      </Stack>
-                    </Box>
-                  </CardBody>
+                          display="flex"
+                          alignItems="center"
+                          justifyContent="center"
+                          height="62%"
+                          width="100%"
+                          bg="gray.200"
+                          borderTopRadius="md"
+                        >
+                          <Text color="gray.500" fontSize="lg">No Image</Text>
+                        </Box>
+                      )}
+                      <Box>
+                        <Stack px='5' spacing='2' py='4'>
+                          <Text mt={1} color="gray.500" textAlign="right">{post.categoryName}</Text>
+
+                          <Heading size='md'>{post.title}</Heading>
+
+                          <Box display='flex' alignItems='center' >
+                            <Text mt={1} color="blue.400">{post.userName}</Text>
+
+                            <Text mt={1} color="blue.400" marginLeft='5'>
+                              {new Date(post.created_at).toLocaleDateString()}
+                            </Text>
+
+                          </Box>
+                          <Box
+                            fontSize={["sm", "md", "lg", "xl"]}
+                            mb={2}
+                            // 文字を２行で省略
+                            sx={{
+                              display: "-webkit-box",
+                              WebkitBoxOrient: "vertical",
+                              WebkitLineClamp: 2,
+                              overflow: "hidden",
+                            }}
+                            dangerouslySetInnerHTML={{ __html: convertDraftContentToHTML(post.content) }}
+                          />
+                        </Stack>
+                      </Box>
+                    </CardBody>
+                  </Link>
                 </Card>
               ))}
             </SimpleGrid>


### PR DESCRIPTION
close #64 

## やったこと・変更内容（ビューの変更がある場合はスクショによる比較などがあるとわかりやすい ）

- 画像サイズのばらつきによる見え方の解消
- イメージが表示できない再『No image』表示
- プロフィールページから詳細ページへの遷移
- プロフィールページのカテゴリ―名及びユーザー名の表示

## レビュー観点（レビューをする際に見てほしい点など）

![スクリーンショット 2024-09-07 144355](https://github.com/user-attachments/assets/aa87fe98-681f-4729-a889-5a4182b12d74)
![スクリーンショット 2024-09-07 144445](https://github.com/user-attachments/assets/224342d6-8cc1-4965-ba57-61e01a02e9e3)

