### PR TITLE
未ログイン時のトーストメッセージの修正

### DIFF
--- a/app/authguard/AuthGuard.tsx
+++ b/app/authguard/AuthGuard.tsx
@@ -23,20 +23,21 @@ export const AuthGuard = ({ children }: Props) => {
       return;
      }
 
-     if(pathname === '/' && user === null) {
+      // ログインしていない状態で特定ページにアクセスした場合
+    if (user === null && (pathname === '/add' || pathname === '/profile')) {
+      if(!toast.isActive('logout-toast') && !sessionStorage.getItem('logout-toast')) {
+        toast({
+          id: 'logout-toast',
+          title:'ログアウトしました',
+          status: 'info',
+          duration: 5000,
+          isClosable: true,
+        });
+        sessionStorage.setItem('logout-toast', 'true');
+      }
+      
+      router.push('/signin');
       return;
-     }
-
-    if (user === null) {
-      toast({
-        title:'ログアウトしました',
-        status: 'info',
-        duration: 5000,
-        isClosable: true,
-      });
-      //ログアウト時にsessionStrageの中身をクリアにする
-      sessionStorage.removeItem('login-toast');
-      router.push('/signin')
     }
 
     if (user && !sessionStorage.getItem('login-toast')){
@@ -49,6 +50,7 @@ export const AuthGuard = ({ children }: Props) => {
           isClosable: true,
         });
         sessionStorage.setItem('login-toast', 'true')
+        sessionStorage.removeItem('logout-toast')
       }
     }
   }, [user, router, toast, pathname])


### PR DESCRIPTION
close #73 

## やったこと・変更内容（ビューの変更がある場合はスクショによる比較などがあるとわかりやすい ）
未ログイン時にAuthGuardでアクセス制限しているページにアクセスする度に「ログアウト」しましたのトーストメッセージが都度表示されてしまうのを修正
- [ ]

## レビュー観点（レビューをする際に見てほしい点など）

-
